### PR TITLE
Fix bug with adding single relation

### DIFF
--- a/src/SaveRelationsBehavior.php
+++ b/src/SaveRelationsBehavior.php
@@ -85,7 +85,7 @@ class SaveRelationsBehavior extends Behavior
             if ($relation->multiple === true) {
                 $newRelations = [];
                 if (!is_array($value)) {
-                    $value = [];
+                    $value = [$value];
                 }
                 foreach ($value as $entry) {
                     if ($entry instanceof $relation->modelClass) {


### PR DESCRIPTION
It seems to relation with has many type would not be added if code looks like this `$model->relationName = 1` or `$model->relationName = $some model`