### PR TITLE
Fixed find bug with missed key of composite fks

### DIFF
--- a/src/SaveRelationsBehavior.php
+++ b/src/SaveRelationsBehavior.php
@@ -182,6 +182,9 @@ class SaveRelationsBehavior extends Behavior
             foreach ($modelClass::primaryKey() as $modelAttribute) {
                 if (array_key_exists($modelAttribute, $data) && !empty($data[$modelAttribute])) {
                     $fks[$modelAttribute] = $data[$modelAttribute];
+                } else {
+                    $fks = [];
+                    break;
                 }
             }
             if (empty($fks)) {

--- a/tests/SaveRelationsBehaviorTest.php
+++ b/tests/SaveRelationsBehaviorTest.php
@@ -326,6 +326,21 @@ class SaveRelationsBehaviorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testCreateHasManyRelationWithOneOfTheMissingKeyOfCompositeFk()
+    {
+        $project = Project::findOne(1);
+        $project->links = [
+            [
+                'language' => 'fr',
+            ]
+        ];
+        $this->assertCount(1, $project->links, 'Project should have 1 links after assignment');
+        $this->assertTrue(
+            $project->links[0]->isNewRecord,
+            'Related link without one of the missed key of composite fk must be is new record'
+        );
+    }
+
     public function testSaveNewHasManyRelationWithCompositeFksAsArrayShouldSucceed()
     {
         $project = Project::findOne(1);


### PR DESCRIPTION
When not all the data of the composite key is specified, I think I need to create a new instance of the model so that it will not be validated in the future. This, of course, for those cases when all parts of the composite key are required. Such cases I think the majority. Probably it is more correct also add a check for the mandatory part of the key and do not skip such to search for existing records.