### PR TITLE
Remove relation models if data[$relationName] is empty

### DIFF
--- a/src/SaveRelationsBehavior.php
+++ b/src/SaveRelationsBehavior.php
@@ -716,9 +716,7 @@ class SaveRelationsBehavior extends Behavior
         $owner = $this->owner;
         foreach ($this->_relations as $relationName) {
             $keyName = $this->_getRelationKeyName($relationName);
-            if (array_key_exists($keyName, $data)) {
-                $owner->{$relationName} = $data[$keyName];
-            }
+            $owner->{$relationName} = $data[$keyName] ?? [];            
         }
     }
 


### PR DESCRIPTION
I think it would be great to remove all models of some relation if I don't post these models from form. So now I can't do it if I remove it from html form.